### PR TITLE
chore(apple): Import SystemConfiguration via a Header search path instead of a module

### DIFF
--- a/ios/RNCNetInfo.m
+++ b/ios/RNCNetInfo.m
@@ -15,7 +15,7 @@
 #import <CoreTelephony/CTCarrier.h>
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #endif
-@import SystemConfiguration.CaptiveNetwork;
+#import <SystemConfiguration/CaptiveNetwork.h>
 
 #import <React/RCTAssert.h>
 #import <React/RCTBridge.h>


### PR DESCRIPTION
# Overview

I'm working on building this library with an internal build system (AKA, not cocoa pods), and noticed that this one line was a clang module import instead of a standard header import. Clang modules don't 100% play nice with our build system and/or React Native, and I see no harm in changing this to be a standard header import


# Test Plan
CI should pass. Is there CI?
